### PR TITLE
XP reset on level up

### DIFF
--- a/app/(auth)/(tabs)/home.tsx
+++ b/app/(auth)/(tabs)/home.tsx
@@ -56,9 +56,11 @@ const Home = () => {
 
     const requiredXPforNextLevel = 50 * (level);
     if (xp >= requiredXPforNextLevel) {
+      const newXP = xp - requiredXPforNextLevel;
       const newLevel = level + 1;
       await userDoc.update({
         level: firestore.FieldValue.increment(1),
+        xp: newXP,
       });
       setLevel(newLevel);
     }

--- a/app/(auth)/quiz.tsx
+++ b/app/(auth)/quiz.tsx
@@ -198,8 +198,9 @@ const Quiz = () => {
           const requiredXPforNextLevel = 50 * (currentLevel);
           const newXP = currentXP + 5;
           if (newXP >= requiredXPforNextLevel) {
+            const updateXP = newXP - requiredXPforNextLevel;
             userRef.update({
-              xp: firestore.FieldValue.increment(5),
+              xp: updateXP,
               level: firestore.FieldValue.increment(1),
             });
           } else {

--- a/components/Scan/ScanResults.tsx
+++ b/components/Scan/ScanResults.tsx
@@ -32,8 +32,9 @@ const ScanResults: React.FC<ScanResultsProps> = ({
           const requiredXPforNextLevel = 50 * (currentLevel);
           const newXP = currentXP + 10;
           if (newXP >= requiredXPforNextLevel) {
+            const updateXP = newXP - requiredXPforNextLevel;
             userRef.update({
-              xp: firestore.FieldValue.increment(10),
+              xp: updateXP,
               level: firestore.FieldValue.increment(1),
             });
           } else {


### PR DESCRIPTION
# Summary
Modified XP incrementing when user logs in, when user scans, and when the user completes the quiz. Now, the user's XP will reset on level up.

# Additional Information
<img src="https://github.com/user-attachments/assets/11bb7f65-c779-4cc9-b933-c27b97c5bb12" width=300>
<img src="https://github.com/user-attachments/assets/d5311dd1-f341-43d2-9ad1-16f20bdef433" width=300>


Closes #59 