### PR TITLE
SafeAreaview Not Applying

### DIFF
--- a/app/(auth)/achievements.tsx
+++ b/app/(auth)/achievements.tsx
@@ -1,7 +1,8 @@
 import BackButton from "@/components/Reusables/BackButton";
 import { Stack } from "expo-router";
 import React, { useEffect, useState } from "react";
-import { View, Text, SafeAreaView } from "react-native";
+import { View, Text} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import firestore, { doc, FieldValue } from "@react-native-firebase/firestore";
 import auth, { FirebaseAuthTypes } from "@react-native-firebase/auth";
 

--- a/app/(auth)/achievements.tsx
+++ b/app/(auth)/achievements.tsx
@@ -3,7 +3,7 @@ import { Stack } from "expo-router";
 import React, { useEffect, useState } from "react";
 import { View, Text} from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import firestore, { doc, FieldValue } from "@react-native-firebase/firestore";
+import firestore from "@react-native-firebase/firestore";
 import auth, { FirebaseAuthTypes } from "@react-native-firebase/auth";
 
 interface Achievement {
@@ -61,7 +61,7 @@ const Achievements = () => {
             />
 
             <View className="flex-1 px-4">
-                <Text className="text-2xl font-bold text-gray-800 mb-4">Achievements</Text>
+                <Text className="text-2xl font-bold text-gray-800 mb-4 text-center">Achievements</Text>
 
                 {/* Achievements List */}
                 {achievements.map((achievement) => {

--- a/app/(auth)/faq.tsx
+++ b/app/(auth)/faq.tsx
@@ -1,7 +1,8 @@
 import BackButton from "@/components/Reusables/BackButton";
 import { Stack } from "expo-router";
 import React, { useState } from "react";
-import { View, Text, SafeAreaView, ScrollView } from "react-native";
+import { View, Text, ScrollView } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 import Accordion from "@/components/Reusables/Accordion";
 const FAQ = () => {
   // list of FAQ


### PR DESCRIPTION
# Summary 
Migrated react-native SafeAreaView to react-native-safe-area-context

# Additional Information
The back button in the header is still covering the top of the screen, but when we implement the hi-fis that will probably be accounted for.

![image](https://github.com/user-attachments/assets/45d965bf-84da-42b6-a8b9-639db0505532)
![image](https://github.com/user-attachments/assets/e7cbd093-8109-4ec1-858c-b9adf56d9fee)


Closes #69 