### PR TITLE
Connect Photo Taking Feature to S3

### DIFF
--- a/components/Scan/ScanResults.tsx
+++ b/components/Scan/ScanResults.tsx
@@ -229,6 +229,7 @@ const ScanResults: React.FC<ScanResultsProps> = ({ image, imageDimensions, setIm
               setImage(null);
             }}
             wasteObjects={wasteObjects}
+            image={image}
           />
       </BottomSheetModalProvider>
   );


### PR DESCRIPTION
Ironically enough after hours of AWS S3 and Amplify documentation, best use case was to use Firebase's Storage feature. On ScanBottomSheetModal's submit button, the image gets stored in zotbins-waste-images/ folder and metadata is stored in the newly created waste-images collection.