### PR TITLE
Progress Ring for Onboarding Slides

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
 import { View, ImageBackground } from "react-native";
+
 import OnboardingSplash from "@/components/Onboarding/OnboardingSplash";
 import OnboardingAbout from "@/components/Onboarding/OnboardingAbout";
-import OnboardingQuiz from "@/components/Onboarding/OnboardingQuizFeature";
 import OnboardingScanner from "@/components/Onboarding/OnboardingScannerFeature";
+import OnboardingQuiz from "@/components/Onboarding/OnboardingQuizFeature";
 import OnboardingAchievements from "@/components/Onboarding/OnboardingAchievements";
 import OnboardingEnd from "@/components/Onboarding/OnboardingEnd";
 
@@ -33,6 +34,15 @@ export default function Onboarding() {
     setCurrentPage(onboardingPages.length - 1);
   };
 
+  const progressMap: Record<number, number> = {
+    0: 0.0,
+    1: 0.25,
+    2: 0.5,
+    3: 0.75,
+    4: 1.0,
+    5: 1.0,
+  };
+
   return (
     <ImageBackground
       source={require("../assets/images/onboarding/background.png")}
@@ -40,7 +50,11 @@ export default function Onboarding() {
       resizeMode="cover"
     >
       <View style={{ flex: 1 }}>
-        <CurrentPageComponent onNext={handleNext} onSkip={handleSkip} />
+        <CurrentPageComponent
+          onNext={handleNext}
+          onSkip={handleSkip}
+          progress={progressMap[currentPage]}
+        />
       </View>
     </ImageBackground>
   );

--- a/components/Onboarding/NextButton.tsx
+++ b/components/Onboarding/NextButton.tsx
@@ -54,26 +54,35 @@ const NextButton: React.FC<NextButtonProps> = ({ onPress, style, progress = 0 })
           originY={ringSize / 2}
         />
       </Svg>
-
-      <Pressable
-        onPress={onPress}
-        className="active:opacity-50"
+      <View
         style={{
-          width: iconSize,
-          height: iconSize,
-          justifyContent: "center",
-          alignItems: "center",
+          shadowColor: "#000",
+          shadowOffset: { width: 0, height: 2 },
+          shadowOpacity: 0.5,
+          shadowRadius: 4,
+          elevation: 4,
         }}
       >
-        <BackIcon
-          width="100%"
-          height="100%"
+        <Pressable
+          onPress={onPress}
+          className="active:opacity-50"
           style={{
-            transform: [{ scaleX: -1 }, { translateY: 4.5 }],
+            width: iconSize,
+            height: iconSize,
+            justifyContent: "center",
+            alignItems: "center",
           }}
-        />
+        >
+          <BackIcon
+            width="100%"
+            height="100%"
+            style={{
+              transform: [{ scaleX: -1 }, { translateY: 4.5 }],
+            }}
+          />
 
-      </Pressable>
+        </Pressable>
+      </View>
 
     </View>
   );

--- a/components/Onboarding/NextButton.tsx
+++ b/components/Onboarding/NextButton.tsx
@@ -40,7 +40,7 @@ const NextButton: React.FC<NextButtonProps> = ({ onPress, style, progress = 0 })
         }}
       >
         <Circle
-          stroke="#00B94A"
+          stroke="#00D363"
           fill="none"
           cx={ringSize / 2}
           cy={ringSize / 2}

--- a/components/Onboarding/NextButton.tsx
+++ b/components/Onboarding/NextButton.tsx
@@ -1,22 +1,81 @@
 import React from "react";
-import { Pressable, StyleProp, ViewStyle } from "react-native";
-import { Ionicons } from "@expo/vector-icons";
+import { View, Pressable, StyleProp, ViewStyle } from "react-native";
+import Svg, { Circle } from "react-native-svg";
 import BackIcon from "@/assets/icons/BackIcon.svg";
 
 interface NextButtonProps {
   onPress: () => void;
   style?: StyleProp<ViewStyle>;
+  progress?: number;
 }
 
-const NextButton: React.FC<NextButtonProps> = ({ onPress, style }) => {
-  return (
-    <Pressable
-      onPress={onPress}
-      className="active:opacity-50 shadow-md"
-    >
-      <BackIcon width={61} height={61} style = {{transform: [{scaleX: -1}]}}/>
-    </Pressable>
+const NextButton: React.FC<NextButtonProps> = ({ onPress, style, progress = 0 }) => {
+  const iconSize = 61;
+  const ringSize = iconSize;
+  const strokeWidth = 3;
+  const radius = (ringSize - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const strokeDashoffset = circumference * (1 - progress);
 
+  return (
+    <View
+      style={[
+        {
+          width: ringSize,
+          height: ringSize,
+          alignItems: "center",
+          justifyContent: "center",
+        },
+        style,
+      ]}
+    >
+      {/* progress ring */}
+      <Svg
+        width={ringSize}
+        height={ringSize}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+        }}
+      >
+        <Circle
+          stroke="#00B94A"
+          fill="none"
+          cx={ringSize / 2}
+          cy={ringSize / 2}
+          r={radius}
+          strokeWidth={strokeWidth}
+          strokeDasharray={circumference}
+          strokeDashoffset={strokeDashoffset}
+          strokeLinecap="round"
+          rotation="-90"
+          originX={ringSize / 2}
+          originY={ringSize / 2}
+        />
+      </Svg>
+
+      <Pressable
+        onPress={onPress}
+        className="active:opacity-50"
+        style={{
+          width: iconSize,
+          height: iconSize,
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
+        <BackIcon
+          width="100%"
+          height="100%"
+          style={{
+            transform: [{ scaleX: -1 }, { translateY: 4.5 }],
+          }}
+        />
+
+      </Pressable>
+
+    </View>
   );
 };
 

--- a/components/Onboarding/OnboardingAbout.tsx
+++ b/components/Onboarding/OnboardingAbout.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import OnboardingPage from "@/components/Onboarding/OnboardingPage";
 import RecycleIcon from "@/assets/images/onboarding/recycle_icon.svg";
 
-const OnboardingAbout = ({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) => {
+interface OnboardingAboutProps {
+  onNext: () => void;
+  onSkip: () => void;
+  progress: number;
+}
+
+const OnboardingAbout: React.FC<OnboardingAboutProps> = ({ onNext, onSkip, progress }) => {
   return (
     <OnboardingPage
       Icon={RecycleIcon}
@@ -10,6 +16,7 @@ const OnboardingAbout = ({ onNext, onSkip }: { onNext: () => void; onSkip: () =>
       bodyText="An innovative smart waste bin system designed to optimize waste management efficiency."
       onNext={onNext}
       onSkip={onSkip}
+      progress={progress}
     />
   );
 };

--- a/components/Onboarding/OnboardingAchievements.tsx
+++ b/components/Onboarding/OnboardingAchievements.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import OnboardingPage from "@/components/Onboarding/OnboardingPage";
 import AchievementsIcon from "@/assets/images/onboarding/achievements_icon.svg";
 
-const OnboardingAchievements = ({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) => {
+interface OnboardingAchievementsProps {
+  onNext: () => void;
+  onSkip: () => void;
+  progress: number;
+}
+
+const OnboardingAchievements: React.FC<OnboardingAchievementsProps> = ({ onNext, onSkip, progress }) => {
   return (
     <OnboardingPage
       Icon={AchievementsIcon}
@@ -10,6 +16,7 @@ const OnboardingAchievements = ({ onNext, onSkip }: { onNext: () => void; onSkip
       bodyText="Unlock rewards by completing missions and achievements."
       onNext={onNext}
       onSkip={onSkip}
+      progress={progress} 
     />
   );
 };

--- a/components/Onboarding/OnboardingPage.tsx
+++ b/components/Onboarding/OnboardingPage.tsx
@@ -8,6 +8,7 @@ interface OnboardingPageProps {
   bodyText: string;
   onNext: () => void;
   onSkip: () => void;
+  progress: number;
 }
 
 const OnboardingPage: React.FC<OnboardingPageProps> = ({
@@ -16,6 +17,7 @@ const OnboardingPage: React.FC<OnboardingPageProps> = ({
   bodyText,
   onNext,
   onSkip,
+  progress,
 }) => {
 
   return (
@@ -83,8 +85,7 @@ const OnboardingPage: React.FC<OnboardingPageProps> = ({
           </Text>
         </Pressable>
 
-        {/* Next Button */}
-        <NextButton onPress={onNext} />
+        <NextButton onPress={onNext} progress={progress} />
       </View>
     </View>
   );

--- a/components/Onboarding/OnboardingQuizFeature.tsx
+++ b/components/Onboarding/OnboardingQuizFeature.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import OnboardingPage from "@/components/Onboarding/OnboardingPage";
 import QuizIcon from "@/assets/images/onboarding/quiz_icon.svg";
 
-const OnboardingQuizFeature = ({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) => {
+interface OnboardingQuizFeatureProps {
+  onNext: () => void;
+  onSkip: () => void;
+  progress: number;
+}
+
+const OnboardingQuizFeature: React.FC<OnboardingQuizFeatureProps> = ({ onNext, onSkip, progress }) => {
   return (
     <OnboardingPage
       Icon={QuizIcon}
@@ -10,6 +16,7 @@ const OnboardingQuizFeature = ({ onNext, onSkip }: { onNext: () => void; onSkip:
       bodyText="Strengthen your knowledge and earn points. Climb the leaderboard and compete with your friends."
       onNext={onNext}
       onSkip={onSkip}
+      progress={progress}
     />
   );
 };

--- a/components/Onboarding/OnboardingScannerFeature.tsx
+++ b/components/Onboarding/OnboardingScannerFeature.tsx
@@ -2,7 +2,13 @@ import React from "react";
 import OnboardingPage from "@/components/Onboarding/OnboardingPage";
 import ScannerIcon from "@/assets/images/onboarding/scanner_icon.svg";
 
-const OnboardingScannerFeature = ({ onNext, onSkip }: { onNext: () => void; onSkip: () => void }) => {
+interface OnboardingScannerFeatureProps {
+  onNext: () => void;
+  onSkip: () => void;
+  progress: number;
+}
+
+const OnboardingScannerFeature: React.FC<OnboardingScannerFeatureProps> = ({ onNext, onSkip, progress }) => {
   return (
     <OnboardingPage
       Icon={ScannerIcon}
@@ -10,6 +16,7 @@ const OnboardingScannerFeature = ({ onNext, onSkip }: { onNext: () => void; onSk
       bodyText="Learn more about proper disposal practices and help contribute to our data collection. Scan to keep your streak up!"
       onNext={onNext}
       onSkip={onSkip}
+      progress={progress}
     />
   );
 };


### PR DESCRIPTION
# Summary
Implemented a progress ring around the 'Next' button that fills as you progress through the onboarding slides. 

# Additional Notes
<p float="left">
  <img src="https://github.com/user-attachments/assets/19ec952e-16d2-4943-baa3-6be4b6a2c029" width="24%" />
  
  <img src = "https://github.com/user-attachments/assets/8f7ffbd2-eba3-411a-a9df-f3ccf228f355" width = 24%/>
  <img src ="https://github.com/user-attachments/assets/0e842ce9-109c-424a-bb81-2e5c18d365eb" width=24%/>


  <img src="https://github.com/user-attachments/assets/79238ad2-fa4d-462b-96f3-24b7ec729892" width="24%" />
</p>

---
Closes #130 


