### PR TITLE
Scan Widget Routing Fixed + Modified Borders of Widgets and FAQ

### DIFF
--- a/app/(auth)/(tabs)/home.tsx
+++ b/app/(auth)/(tabs)/home.tsx
@@ -95,27 +95,21 @@ const Home = () => {
         restoresLeft={userDoc?.restoresLeft || 0}
       />
       <SafeAreaView style={{ flex: 1 }} className="bg-[#F5FFF5]">
-
-      <LinearGradient
-        colors={["#F5FFF5", "#DBFFD8"]}
-        style={{ flex: 1 }}
-      >
-        <ScrollView
-          contentContainerStyle={{ paddingBottom: 100 }}
-          showsVerticalScrollIndicator={false}
+        <LinearGradient colors={["#F5FFF5", "#DBFFD8"]} style={{ flex: 1 }}>
+          <ScrollView
+            contentContainerStyle={{ paddingBottom: 100 }}
+            showsVerticalScrollIndicator={false}
           >
-          <View className="flex-1 px-5 gap-2 pb-24">
-            <Header username={userDoc?.username || "User"} />
-            <EnvImpactPreview />
-            <ScanWidget scans={3 - userDoc?.dailyScans || 0} />
-            <DailyQuizWidget />
-
-            <MissionsWidget />
-
-
-          </View>
-        </ScrollView>
-      </LinearGradient>
+            <View className="flex-1 px-5 gap-2 pb-24">
+              
+              <Header username={userDoc?.username || "User"} />
+              <EnvImpactPreview />
+              <ScanWidget scans={3 - userDoc?.dailyScans || 0} />
+              <DailyQuizWidget />
+              <MissionsWidget />
+            </View>
+          </ScrollView>
+        </LinearGradient>
       </SafeAreaView>
     </>
   );

--- a/app/(auth)/(tabs)/profile.tsx
+++ b/app/(auth)/(tabs)/profile.tsx
@@ -1,4 +1,4 @@
-import { useUserContext } from "@/context/UserProvider"
+import { useUserContext } from "@/context/UserProvider";
 import {
   getStorage,
   ref,
@@ -91,7 +91,7 @@ const Profile = () => {
 
       uploadTask.on(
         "state_changed",
-        () => { },
+        () => {},
         (error) => {
           console.error(error);
         },
@@ -110,9 +110,7 @@ const Profile = () => {
 
       <LinearGradient colors={["#F5FFF5", "#DBFFD8"]} style={{ flex: 1 }}>
         <SafeAreaView className="flex-1 px-5 gap-2">
-          <ScrollView
-            showsVerticalScrollIndicator={false}
-          >
+          <ScrollView showsVerticalScrollIndicator={false}>
             <View className="flex justify-center items-center w-full">
               <View className="w-11/12 flex flex-row justify-between items-baseline h-16">
                 <SimpleLogoSvg width={100} height={100} />
@@ -192,9 +190,13 @@ const Profile = () => {
             </View>
 
             <View className="flex flex-row items-center mt-6 ml-4 mb-4">
-              <Text className="text-2xl font-bold text-darkGreen">Achievements</Text>
+              <Text className="text-2xl font-bold text-darkGreen">
+                Achievements
+              </Text>
               <Pressable onPress={() => router.push("/achievements")}>
-                <Text className="text-md text-darkGreen underline mt-1 ml-2">See all</Text>
+                <Text className="text-md text-darkGreen underline mt-1 ml-2">
+                  See all
+                </Text>
               </Pressable>
             </View>
             <AchievementsList limit={5} containerStyle="px-2 w-full mb-24" />

--- a/components/Achievements/AchievementWidget.tsx
+++ b/components/Achievements/AchievementWidget.tsx
@@ -20,112 +20,138 @@ import ScannerIconGray from "@/assets/icons/scanner-icon-gray.svg";
 import StarIconGray from "@/assets/icons/star-icon-gray.svg";
 
 interface AchievementProps {
-    achievement: {
-        id: number;
-        name: string;
-        description: string;
-        reward: string;
-        actionAmount: number;
-        progress: number;
-        userStatus?: boolean;
-        dateAchieved?: Timestamp | null;
-        actionType: string;
-    };
+  achievement: {
+    id: number;
+    name: string;
+    description: string;
+    reward: string;
+    actionAmount: number;
+    progress: number;
+    userStatus?: boolean;
+    dateAchieved?: Timestamp | null;
+    actionType: string;
+  };
 }
 
 const Achievement = ({ achievement }: AchievementProps) => {
-    const { progress, actionAmount, name, dateAchieved, userStatus, description, actionType } = achievement;
-    const isCompleted = userStatus;
+  const {
+    progress,
+    actionAmount,
+    name,
+    dateAchieved,
+    userStatus,
+    description,
+    actionType,
+  } = achievement;
+  const isCompleted = userStatus;
 
-    const fraction = `(${progress}/${actionAmount})`;
+  const fraction = `(${progress}/${actionAmount})`;
 
-    const greenColor = "#008229";
-    const grayColor = "#878787";
+  const greenColor = "#008229";
+  const grayColor = "#878787";
 
-    // Format date as MM/DD/YY
-    const getFormattedDate = (): string => {
-        if (!dateAchieved) return "00/00/00"; // default date (shouldnt happen)
+  // Format date as MM/DD/YY
+  const getFormattedDate = (): string => {
+    if (!dateAchieved) return "00/00/00"; // default date (shouldnt happen)
 
-        try {
-            const date = dateAchieved.toDate();
-            const month = String(date.getMonth() + 1).padStart(2, '0');
-            const day = String(date.getDate()).padStart(2, '0');
-            const year = String(date.getFullYear()).slice(-2);
-            return `${month}/${day}/${year}`;
-        } catch (error) {
-            return "00/00/00";
-        }
-    };
+    try {
+      const date = dateAchieved.toDate();
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
+      const year = String(date.getFullYear()).slice(-2);
+      return `${month}/${day}/${year}`;
+    } catch (error) {
+      return "00/00/00";
+    }
+  };
 
-    const formattedDateString = getFormattedDate();
+  const formattedDateString = getFormattedDate();
 
-    // display random icon for now since i'm not sure how we are going to specify which achievement gets which icon
-    const getIcon = (actionType: string) => {
-        const icons = isCompleted ? [
-            <ArrowIcon width={60} height={60} />,
-            <CheckIcon width={40} height={40} />,
-            <RibbonIcon width={40} height={40} />,
-            <ScannerIcon width={40} height={40} />,
-            <StarIcon width={40} height={40} />
-        ] : [
-            <ArrowIconGray width={60} height={60} />,
-            <CheckIconGray width={40} height={40} />,
-            <RibbonIconGray width={40} height={40} />,
-            <ScannerIconGray width={40} height={40} />,
-            <StarIconGray width={40} height={40} />
+  // display random icon for now since i'm not sure how we are going to specify which achievement gets which icon
+  const getIcon = (actionType: string) => {
+    const icons = isCompleted
+      ? [
+          <ArrowIcon width={60} height={60} />,
+          <CheckIcon width={40} height={40} />,
+          <RibbonIcon width={40} height={40} />,
+          <ScannerIcon width={40} height={40} />,
+          <StarIcon width={40} height={40} />,
+        ]
+      : [
+          <ArrowIconGray width={60} height={60} />,
+          <CheckIconGray width={40} height={40} />,
+          <RibbonIconGray width={40} height={40} />,
+          <ScannerIconGray width={40} height={40} />,
+          <StarIconGray width={40} height={40} />,
         ];
-        const actionMap: { [key: string]: number } = {"level": 0, "mission": 1, "quiz": 2, "scan": 3, "points": 4};
-        return icons[actionMap[actionType]];
+    const actionMap: { [key: string]: number } = {
+      level: 0,
+      mission: 1,
+      quiz: 2,
+      scan: 3,
+      points: 4,
     };
+    return icons[actionMap[actionType]];
+  };
 
-    return (
-        <View className="mb-3 shadow-sm">
-            {/* Gradient Border Container */}
-            <LinearGradient
-                colors={
-                    isCompleted
-                        ? [greenColor, "#DFFFE3", "#B4FABD", "#004C18"]
-                        : [grayColor, "#D0D0D0", "#B4B4B4", "#333333"]
-                }
-                start={{ x: 0, y: 0 }}
-                end={{ x: 1, y: 1 }}
-                locations={[0.1, 0.5, 0.8, 1]}
-                style={{
-                    padding: 1.3,
-                    borderRadius: 35,
-                }}
-                className="mb-4 shadow-lg"
+  return (
+    <View className="mb-3 shadow-sm">
+      {/* Gradient Border Container */}
+      <LinearGradient
+        colors={
+          isCompleted
+            ? [greenColor, "#DFFFE3", "#B4FABD", "#004C18"]
+            : [grayColor, "#D0D0D0", "#B4B4B4", "#333333"]
+        }
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        locations={[0.1, 0.5, 0.8, 1]}
+        style={{
+          padding: 1.3,
+          borderRadius: 35,
+        }}
+        className="mb-4 shadow-lg"
+      >
+        {/* Achievement Content */}
+        <View
+          className={`${
+            isCompleted ? "bg-lightBackground" : "bg-[#e5ebe6]"
+          } p-4 rounded-[33] flex flex-row items-center`}
+        >
+          <View className="w-24 h-24 flex items-center justify-center">
+            {getIcon(actionType)}
+          </View>
+          <View className="ml-4 flex-1 mr-2">
+            <Text
+              className={`text-2xl font-bold ${
+                isCompleted ? "text-darkestGreen" : "text-mainTextGray"
+              }`}
             >
-                {/* Achievement Content */}
-                <View className={`${isCompleted ? "bg-lightBackground" : "bg-[#e5ebe6]"} p-4 rounded-[33] flex flex-row items-center`}>
-                    <View className="w-24 h-24 flex items-center justify-center">
-                        {getIcon(actionType)}
-                    </View>
-                    <View className="ml-4 flex-1 mr-2">
-                        <Text className={`text-2xl font-bold ${isCompleted ? "text-darkestGreen" : "text-mainTextGray"}`}>
-                            {name} {!isCompleted && fraction}
-                        </Text>
-                        <Text className={`mt-1 ${isCompleted ? "text-darkGreen" : "text-textGray"}`}>
-                            {description || "Description example"}
-                        </Text>
+              {name} {!isCompleted && fraction}
+            </Text>
+            <Text
+              className={`mt-1 ${
+                isCompleted ? "text-darkGreen" : "text-textGray"
+              }`}
+            >
+              {description || "Description example"}
+            </Text>
 
-                        {/* Show progress bar for uncompleted achievements */}
-                        {!isCompleted ? (
-                            <ProgressBar progress={progress} actionAmount={actionAmount} />
-                        ) : (
-                            // Show date achieved for completed achievements
-                            <View className="mt-1 flex flex-row items-center">
-                                <CalendarIcon width={16} height={16} />
-                                <Text className="ml-3 text-gray">
-                                    {formattedDateString}
-                                </Text>
-                            </View>
-                        )}
-                    </View>
-                </View>
-            </LinearGradient>
+            {/* Show progress bar for uncompleted achievements */}
+            {!isCompleted ? (
+              <ProgressBar progress={progress} actionAmount={actionAmount} />
+            ) : (
+              // Show date achieved for completed achievements
+              <View className="mt-1 flex flex-row items-center">
+                <CalendarIcon width={16} height={16} />
+                <Text className="ml-3 text-gray">{formattedDateString}</Text>
+              </View>
+            )}
+          </View>
         </View>
-    );
+      </LinearGradient>
+    </View>
+  );
 };
 
 export default Achievement;

--- a/components/Home/DailyQuizWidget.tsx
+++ b/components/Home/DailyQuizWidget.tsx
@@ -1,41 +1,56 @@
-import { Pressable, StyleSheet, Text, View } from 'react-native';
-import React from 'react';
-import { Ionicons } from '@expo/vector-icons';
-import { router } from 'expo-router';
-import { LinearGradient } from 'expo-linear-gradient';
-
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import React from "react";
+import { Ionicons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import { LinearGradient } from "expo-linear-gradient";
 
 const handleQuiz = () => {
-    router.push('/(auth)/quiz');
-}
+  router.push("/(auth)/quiz");
+};
 
 const DailyQuizWidget = () => {
   return (
-    <LinearGradient
-    colors={['#004c18', '#DFFFE3', '#DFFFE3', '#004c18']}
-    style={{ padding: 1, borderRadius: 35, shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.4, shadowRadius: 3.84 }}
-    start={{ x: 0, y: 0 }}
-    end={{ x: 1, y: 1 }}
-    className="mb-4 shadow-lg"
-    locations={[0, 0.1, 0.9, 1]}
->
-    <View style={{ borderRadius: 35 }} className="bg-lightBackground p-5 w-full">
-        <Text className="text-darkGreen text-2xl font-semibold mb-2">Daily Quiz</Text>
-        <Text className="text-darkGreen text-lg font-normal">Can you recycle Styrofoam?</Text>
-        <Text className="text-darkGreen text-lg font-normal">Find out here!</Text>
-        <View className="flex-row items-center justify-end">
+    <View className="mb-3 shadow-sm">
+      <LinearGradient
+        colors={["#008229", "#DFFFE3", "#B4FABD", "#004C18"]}
+        style={{
+          padding: 1,
+          borderRadius: 35,
+        }}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        className="mb-4 shadow-lg"
+        locations={[0.1, 0.5, 0.8, 1]}
+      >
+        <View
+          style={{ borderRadius: 35 }}
+          className="bg-lightBackground p-5 w-full"
+        >
+          <Text className="text-darkGreen text-2xl font-semibold mb-2">
+            Daily Quiz
+          </Text>
+          <Text className="text-darkGreen text-lg font-normal">
+            Can you recycle Styrofoam?
+          </Text>
+          <Text className="text-darkGreen text-lg font-normal">
+            Find out here!
+          </Text>
+          <View className="flex-row items-center justify-end">
             <Pressable
-                onPress={handleQuiz}
-                className="bg-primaryGreen rounded-full p-3 px-6 border border-darkGreen"
+              onPress={handleQuiz}
+              className="bg-primaryGreen rounded-full p-3 px-6 border border-darkGreen"
             >
-                <Text className="text-white font-semibold text-md">Start Quiz</Text>
+              <Text className="text-white font-semibold text-md">
+                Start Quiz
+              </Text>
             </Pressable>
+          </View>
         </View>
+      </LinearGradient>
     </View>
-</LinearGradient>
-  )
-}
+  );
+};
 
-export default DailyQuizWidget
+export default DailyQuizWidget;
 
-const styles = StyleSheet.create({})
+const styles = StyleSheet.create({});

--- a/components/Home/MissionsWidget.tsx
+++ b/components/Home/MissionsWidget.tsx
@@ -1,6 +1,12 @@
 import { ScrollView, Text, View, Dimensions } from "react-native";
 import React, { useEffect, useState, useRef } from "react";
-import { getFirestore, collection, query, where, onSnapshot } from "@react-native-firebase/firestore";
+import {
+  getFirestore,
+  collection,
+  query,
+  where,
+  onSnapshot,
+} from "@react-native-firebase/firestore";
 import { getAuth, FirebaseAuthTypes } from "@react-native-firebase/auth";
 import { LinearGradient } from "expo-linear-gradient";
 import MissionItem from "./MissionItem";
@@ -8,136 +14,151 @@ import MissionItem from "./MissionItem";
 const screenWidth = Dimensions.get("window").width;
 
 interface Mission {
-    id?: string;
-    description: string;
-    reward: string;
-    status: boolean;
-    progress: number;
-    name: string;
-    type: string;
-    userStatus: boolean;
-    actionAmount?: number;
+  id?: string;
+  description: string;
+  reward: string;
+  status: boolean;
+  progress: number;
+  name: string;
+  type: string;
+  userStatus: boolean;
+  actionAmount?: number;
 }
 
 const MissionsWidget = () => {
-    const [dailyMissions, setDailyMissions] = useState<Mission[]>([]);
-    const [weeklyMissions, setWeeklyMissions] = useState<Mission[]>([]);
-    const [widgetWidth, setWidgetWidth] = useState<number>(0); // Track widget width
-    const [currentIndex, setCurrentIndex] = useState(0); // Track current screen index
-    const scrollViewRef = useRef<ScrollView>(null);
-    const user = getAuth().currentUser;
+  const [dailyMissions, setDailyMissions] = useState<Mission[]>([]);
+  const [weeklyMissions, setWeeklyMissions] = useState<Mission[]>([]);
+  const [widgetWidth, setWidgetWidth] = useState<number>(0); // Track widget width
+  const [currentIndex, setCurrentIndex] = useState(0); // Track current screen index
+  const scrollViewRef = useRef<ScrollView>(null);
+  const user = getAuth().currentUser;
 
-    // Set up listener so missions are updated in real time
-    useEffect(() => {
-        if (!user) {
-            console.error("User is not logged in");
-            return;
-        }
+  // Set up listener so missions are updated in real time
+  useEffect(() => {
+    if (!user) {
+      console.error("User is not logged in");
+      return;
+    }
 
-        const db = getFirestore();
-        const missionsCollectionRef = collection(db, "users", user.uid, "missions");
-        const missionQuery = query(missionsCollectionRef, where('status', '==', true));
-        
-        const unsubscribe = onSnapshot(missionQuery, (querySnapshot) => {
-            const allMissions: Mission[] = [];
-            querySnapshot.forEach((doc) => {
-                const data = doc.data();
-                allMissions.push({
-                    id: doc.id,
-                    description: data.description,
-                    reward: data.reward,
-                    status: data.status,
-                    progress: data.progress,
-                    name: data.name,
-                    type: data.type,
-                    userStatus: data.userStatus,
-                    actionAmount: data.actionAmount,
-                });
-            });
-
-            const allDailyMissions = allMissions.filter((mission) => mission.type === "daily");
-            const allWeeklyMissions = allMissions.filter((mission) => mission.type === "weekly");
-
-            setDailyMissions(allDailyMissions);
-            setWeeklyMissions(allWeeklyMissions);
-        }, (error) => {
-            console.error("Error fetching missions: ", error);
-        });
-        
-        return () => unsubscribe();
-    }, [user]);
-
-    const handleScroll = (event: any) => {
-        const contentOffsetX = event.nativeEvent.contentOffset.x;
-        const index = Math.round(contentOffsetX / widgetWidth);
-        setCurrentIndex(index);
-    };
-
-    return (
-        <LinearGradient
-            colors={["#004c18", "#DFFFE3", "#DFFFE3", "#004c18"]}
-            style={{
-                padding: 1,
-                borderRadius: 35,
-                shadowColor: "#000",
-                shadowOffset: { width: 0, height: 2 },
-                shadowOpacity: 0.4,
-                shadowRadius: 3.84,
-            }}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
-            className="mb-4 shadow-lg"
-            locations={[0, 0.1, 0.9, 1]}
-        >
-            <View
-                style={{ borderRadius: 35 }}
-                className="bg-lightBackground w-full py-5"
-                onLayout={(event) => setWidgetWidth(event.nativeEvent.layout.width)} // Capture widget width
-            >
-                <Text className="text-darkGreen text-2xl font-semibold px-5">Missions</Text>
-
-                <ScrollView
-                    ref={scrollViewRef}
-                    horizontal
-                    pagingEnabled
-                    showsHorizontalScrollIndicator={false}
-                    snapToAlignment="center"
-                    snapToInterval={widgetWidth} // Use dynamic widget width
-                    decelerationRate="fast"
-                    className="pl-5"
-                    onScroll={handleScroll} // Track scroll position
-                    scrollEventThrottle={16}
-                >
-                    
-                    <View style={{ width: widgetWidth }} className="">
-                        <Text className="text-2xl font-base text-darkGreen mb-2">Daily</Text>
-                        {dailyMissions.map((mission) => (
-                            <MissionItem key={mission.id} mission={mission} />
-                        ))}
-                    </View>
-
-                
-                    <View style={{ width: widgetWidth }} className="">
-                        <Text className="text-2xl font-base text-darkGreen mb-2">Weekly</Text>
-                        {weeklyMissions.map((mission) => (
-                            <MissionItem key={mission.id} mission={mission} />
-                        ))}
-                    </View>
-                </ScrollView>
-
-                {/* navigation dots */}
-                <View className="flex-row justify-center mt-3">
-                    {[0, 1].map((index) => (
-                        <View
-                            key={index}
-
-                            className={"w-3 h-3 rounded-full mx-1 " + (currentIndex === index ? "bg-primaryGreen" : "bg-grey")}
-                        />
-                    ))}
-                </View>
-            </View>
-        </LinearGradient>
+    const db = getFirestore();
+    const missionsCollectionRef = collection(db, "users", user.uid, "missions");
+    const missionQuery = query(
+      missionsCollectionRef,
+      where("status", "==", true)
     );
+
+    const unsubscribe = onSnapshot(
+      missionQuery,
+      (querySnapshot) => {
+        const allMissions: Mission[] = [];
+        querySnapshot.forEach((doc) => {
+          const data = doc.data();
+          allMissions.push({
+            id: doc.id,
+            description: data.description,
+            reward: data.reward,
+            status: data.status,
+            progress: data.progress,
+            name: data.name,
+            type: data.type,
+            userStatus: data.userStatus,
+            actionAmount: data.actionAmount,
+          });
+        });
+
+        const allDailyMissions = allMissions.filter(
+          (mission) => mission.type === "daily"
+        );
+        const allWeeklyMissions = allMissions.filter(
+          (mission) => mission.type === "weekly"
+        );
+
+        setDailyMissions(allDailyMissions);
+        setWeeklyMissions(allWeeklyMissions);
+      },
+      (error) => {
+        console.error("Error fetching missions: ", error);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [user]);
+
+  const handleScroll = (event: any) => {
+    const contentOffsetX = event.nativeEvent.contentOffset.x;
+    const index = Math.round(contentOffsetX / widgetWidth);
+    setCurrentIndex(index);
+  };
+
+  return (
+    <View className="mb-3 shadow-sm">
+      <LinearGradient
+        colors={["#008229", "#DFFFE3", "#B4FABD", "#004C18"]}
+        style={{
+          padding: 1,
+          borderRadius: 35,
+        }}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        className="mb-4 shadow-lg"
+        locations={[0.1, 0.5, 0.8, 1]}
+      >
+        <View
+          style={{ borderRadius: 35 }}
+          className="bg-lightBackground w-full py-5"
+          onLayout={(event) => setWidgetWidth(event.nativeEvent.layout.width)} // Capture widget width
+        >
+          <Text className="text-darkGreen text-2xl font-semibold px-5">
+            Missions
+          </Text>
+
+          <ScrollView
+            ref={scrollViewRef}
+            horizontal
+            pagingEnabled
+            showsHorizontalScrollIndicator={false}
+            snapToAlignment="center"
+            snapToInterval={widgetWidth} // Use dynamic widget width
+            decelerationRate="fast"
+            className="pl-5"
+            onScroll={handleScroll} // Track scroll position
+            scrollEventThrottle={16}
+          >
+            <View style={{ width: widgetWidth }} className="">
+              <Text className="text-2xl font-base text-darkGreen mb-2">
+                Daily
+              </Text>
+              {dailyMissions.map((mission) => (
+                <MissionItem key={mission.id} mission={mission} />
+              ))}
+            </View>
+
+            <View style={{ width: widgetWidth }} className="">
+              <Text className="text-2xl font-base text-darkGreen mb-2">
+                Weekly
+              </Text>
+              {weeklyMissions.map((mission) => (
+                <MissionItem key={mission.id} mission={mission} />
+              ))}
+            </View>
+          </ScrollView>
+
+          {/* navigation dots */}
+          <View className="flex-row justify-center mt-3">
+            {[0, 1].map((index) => (
+              <View
+                key={index}
+                className={
+                  "w-3 h-3 rounded-full mx-1 " +
+                  (currentIndex === index ? "bg-primaryGreen" : "bg-grey")
+                }
+              />
+            ))}
+          </View>
+        </View>
+      </LinearGradient>
+    </View>
+  );
 };
 
 export default MissionsWidget;

--- a/components/Home/ScanWidget.tsx
+++ b/components/Home/ScanWidget.tsx
@@ -1,59 +1,68 @@
-import { Pressable, StyleSheet, Text, View } from 'react-native';
-import React from 'react';
-import { Ionicons } from '@expo/vector-icons';
-import { router } from 'expo-router';
-import { LinearGradient } from 'expo-linear-gradient';
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import React from "react";
+import { Ionicons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import { LinearGradient } from "expo-linear-gradient";
 
 const handleScan = () => {
-    router.push('/scan');
+  router.push("/(auth)/camera");
 };
 
 const ScanCount = ({ count }: { count: number }) => (
-    <View>
-        <LinearGradient
-            colors={['#004c18', '#7bff90', '#44ff5c']}
-            style={{ borderRadius: 200, padding: 1 }}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 0.5 }}
-        >
-            <View className="rounded-full items-center justify-center p-3 bg-lightBackground">
-                <Text className="text-darkGreen text-md font-semibold">
-                    {count}
-                    <Text className="font-normal"> left</Text>
-                </Text>
-            </View>
-        </LinearGradient>
-    </View>
+  <View>
+    <LinearGradient
+      colors={["#004c18", "#7bff90", "#44ff5c"]}
+      style={{ borderRadius: 200, padding: 1 }}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 0.5 }}
+    >
+      <View className="rounded-full items-center justify-center p-3 bg-lightBackground">
+        <Text className="text-darkGreen text-md font-semibold">
+          {count}
+          <Text className="font-normal"> left</Text>
+        </Text>
+      </View>
+    </LinearGradient>
+  </View>
 );
 
 const ScanWidget = ({ scans }: { scans: number }) => (
+  <View className="mb-3 shadow-sm">
     <LinearGradient
-        colors={['#004c18', '#DFFFE3', '#DFFFE3', '#004c18']}
-        style={{ padding: 1, borderRadius: 35, shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.4, shadowRadius: 3.84 }}
-        start={{ x: 0, y: 0 }}
-        end={{ x: 1, y: 1 }}
-        className="mb-4 shadow-lg"
-        locations={[0, 0.1, 0.9, 1]}
+      colors={["#008229", "#DFFFE3", "#B4FABD", "#004C18"]}
+      style={{
+        padding: 1,
+        borderRadius: 35,
+      }}
+      start={{ x: 0, y: 0 }}
+      end={{ x: 1, y: 1 }}
+      className="mb-4 shadow-lg"
+      locations={[0.1, 0.5, 0.8, 1]}
     >
-        <View style={{ borderRadius: 35 }} className="bg-lightBackground p-5 w-full">
-            <View className="flex-row items-center justify-between mb-2">
-                <Text className="text-darkGreen text-2xl font-semibold">Scan Limit</Text>
-                <Pressable onPress={() => router.push('/(auth)/faq')}>
-                    <Ionicons name="help-circle-outline" size={24} color="#00762b" />
-                </Pressable>
-            </View>
-            <View className="flex-row items-center justify-between">
-                <ScanCount count={scans} />
-                <Pressable
-                    onPress={handleScan}
-                    className="bg-primaryGreen rounded-full p-3 px-6 border border-darkGreen"
-                >
-                    <Text className="text-white font-semibold text-md">Scan Item</Text>
-                </Pressable>
-            </View>
+      <View
+        style={{ borderRadius: 35 }}
+        className="bg-lightBackground p-5 w-full"
+      >
+        <View className="flex-row items-center justify-between mb-2">
+          <Text className="text-darkGreen text-2xl font-semibold">
+            Scan Limit
+          </Text>
+          <Pressable onPress={() => router.push("/(auth)/faq")}>
+            <Ionicons name="help-circle-outline" size={24} color="#00762b" />
+          </Pressable>
         </View>
+        <View className="flex-row items-center justify-between">
+          <ScanCount count={scans} />
+          <Pressable
+            onPress={handleScan}
+            className="bg-primaryGreen rounded-full p-3 px-6 border border-darkGreen"
+          >
+            <Text className="text-white font-semibold text-md">Scan Item</Text>
+          </Pressable>
+        </View>
+      </View>
     </LinearGradient>
+  </View>
 );
 
 export default ScanWidget;
-

--- a/components/Reusables/AccordionItem.tsx
+++ b/components/Reusables/AccordionItem.tsx
@@ -2,12 +2,12 @@ import { Entypo } from "@expo/vector-icons";
 import React, { useState, useEffect } from "react";
 import { View, TouchableOpacity, Text, Pressable } from "react-native";
 import { LinearGradient } from "expo-linear-gradient";
-import Animated, { 
-  useSharedValue, 
-  useAnimatedStyle, 
-  withTiming, 
-  Easing 
-} from 'react-native-reanimated';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+} from "react-native-reanimated";
 
 interface AccordionItemProps {
   question: string;
@@ -21,10 +21,10 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
   row,
 }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
-  
+
   // Create a shared value for rotation angle
   const rotateValue = useSharedValue(0);
-  
+
   // Update rotation value when isOpen changes
   useEffect(() => {
     rotateValue.value = withTiming(isOpen ? 90 : 0, {
@@ -32,40 +32,47 @@ const AccordionItem: React.FC<AccordionItemProps> = ({
       easing: Easing.bezier(0.25, 0.1, 0.25, 1),
     });
   }, [isOpen]);
-  
+
   // Create animated style for rotation
   const animatedStyle = useAnimatedStyle(() => {
     return {
       transform: [{ rotate: `${rotateValue.value}deg` }],
     };
   });
-  
+
   return (
-    <LinearGradient
-      colors={['#004c18', '#DFFFE3', '#DFFFE3', '#004c18']}
-      style={{ padding: 1, borderRadius: 12, shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.4, shadowRadius: 3.84 }}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      className="mb-4 shadow-lg rounded-lg"
-      locations={[0, 0.1, 0.9, 1]}
-    >
-      <Pressable
-        onPress={() => setIsOpen(!isOpen)}
-        className="bg-lightBackground rounded-xl p-4"
+    <View className="mb-3 shadow-sm">
+      <LinearGradient
+        colors={["#008229", "#DFFFE3", "#B4FABD", "#004C18"]}
+        style={{
+          padding: 1,
+          borderRadius: 10,
+        }}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        className="mb-4 shadow-lg"
+        locations={[0.1, 0.5, 0.8, 1]}
       >
-        <View className="flex flex-row items-center ">
-          <Animated.View style={animatedStyle}>
-            <Entypo name="chevron-right" size={24} color="#00762B" />
-          </Animated.View>
-          <Text className="ml-4 font-bold text-xl text-mediumGreen w-5/6">{question}</Text>
-        </View>
-        {isOpen && (
-          <View className=" flex flex-row items-center p-2 pb-0">
-            <Text className=" text-mediumGreen">{answer}</Text>
+        <Pressable
+          onPress={() => setIsOpen(!isOpen)}
+          className="bg-lightBackground rounded-xl p-4"
+        >
+          <View className="flex flex-row items-center">
+            <Animated.View style={animatedStyle}>
+              <Entypo name="chevron-right" size={24} color="#00762B" />
+            </Animated.View>
+            <Text className="ml-4 font-bold text-xl text-mediumGreen w-5/6">
+              {question}
+            </Text>
           </View>
-        )}
-      </Pressable>
-    </LinearGradient>
+          {isOpen && (
+            <View className=" flex flex-row items-center p-2 pb-0">
+              <Text className=" text-mediumGreen">{answer}</Text>
+            </View>
+          )}
+        </Pressable>
+      </LinearGradient>
+    </View>
   );
 };
 

--- a/components/Reusables/EnvImpactPreview.tsx
+++ b/components/Reusables/EnvImpactPreview.tsx
@@ -102,59 +102,71 @@ const EnvImpactPreview = () => {
   };
 
   return (
-    <LinearGradient
-      colors={['#004c18', '#DFFFE3', '#DFFFE3', '#004c18']}
-      style={{ padding: 1, borderRadius: 35, shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.4, shadowRadius: 3.84 }}
-      start={{ x: 0, y: 0 }}
-      end={{ x: 1, y: 1 }}
-      className="mb-4 shadow-lg"
-      locations={[0, 0.1, 0.9, 1]}
-    >
-      <Pressable
-        style={{ padding: 1, borderRadius: 35, shadowColor: '#000', shadowOffset: { width: 0, height: 7 }, shadowOpacity: 0.4, shadowRadius: 3.84 }}
-        className="flex-row py-8 rounded-[33px] justify-evenly bg-lightBackground"
-        onPress={() => router.push("/envimpact")}
+    <View className="mb-3 shadow-sm">
+      <LinearGradient
+        colors={["#008229", "#DFFFE3", "#B4FABD", "#004C18"]}
+        style={{
+          padding: 1,
+          borderRadius: 35,
+        }}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        className="mb-4 shadow-lg"
+        locations={[0.1, 0.5, 0.8, 1]}
       >
-        <View className="absolute top-4 right-4">
-          <ChevronRight/>
-        </View>
-        {/* carbon footprint stats*/}
-        <View className="flex-col items-center justify-center px-3">
-          <Text className="text-darkestGreen text-lg font-semibold">
-            {calculateCO2Saved()}
-          </Text>
-          <Text className="text-darkestGreen text-lg font-semibold">
-            CO₂ saved
-          </Text>
-        </View>
+        <Pressable
+          style={{
+            padding: 1,
+            borderRadius: 35,
+            shadowColor: "#000",
+            shadowOffset: { width: 0, height: 7 },
+            shadowOpacity: 0.4,
+            shadowRadius: 3.84,
+          }}
+          className="flex-row py-8 rounded-[33px] justify-evenly bg-lightBackground"
+          onPress={() => router.push("/envimpact")}
+        >
+          <View className="absolute top-4 right-4">
+            <ChevronRight />
+          </View>
+          {/* carbon footprint stats*/}
+          <View className="flex-col items-center justify-center px-3">
+            <Text className="text-darkestGreen text-lg font-semibold">
+              {calculateCO2Saved()}
+            </Text>
+            <Text className="text-darkestGreen text-lg font-semibold">
+              CO₂ saved
+            </Text>
+          </View>
 
-        {/* vertical divider */}
-        <View className="w-px h-full bg-gray-200 self-center"></View>
+          {/* vertical divider */}
+          <View className="w-px h-full bg-gray-200 self-center"></View>
 
-        <View className="flex-col justify-center items-center px-3">
-          <Text className="text-darkestGreen text-lg font-semibold">
-            {userDoc?.landfillScanned || 0} items
-          </Text>
-          <Text className="text-darkestGreen text-lg font-semibold">
-            {" "}
-            discarded
-          </Text>
-        </View>
+          <View className="flex-col justify-center items-center px-3">
+            <Text className="text-darkestGreen text-lg font-semibold">
+              {userDoc?.landfillScanned || 0} items
+            </Text>
+            <Text className="text-darkestGreen text-lg font-semibold">
+              {" "}
+              discarded
+            </Text>
+          </View>
 
-        {/* vertical divider */}
-        <View className="w-px h-full bg-gray-200 self-center"></View>
+          {/* vertical divider */}
+          <View className="w-px h-full bg-gray-200 self-center"></View>
 
-        <View className="flex-col justify-center items-center px-3 mr-4">
-          <Text className="text-darkestGreen text-lg font-semibold">
-            {userDoc?.recyclableScanned || 0} items
-          </Text>
-          <Text className="text-darkestGreen text-lg font-semibold">
-            {" "}
-            recycled
-          </Text>
-        </View>
-      </Pressable>
-    </LinearGradient>
+          <View className="flex-col justify-center items-center px-3 mr-4">
+            <Text className="text-darkestGreen text-lg font-semibold">
+              {userDoc?.recyclableScanned || 0} items
+            </Text>
+            <Text className="text-darkestGreen text-lg font-semibold">
+              {" "}
+              recycled
+            </Text>
+          </View>
+        </Pressable>
+      </LinearGradient>
+    </View>
   );
 };
 

--- a/components/Reusables/Header.tsx
+++ b/components/Reusables/Header.tsx
@@ -13,9 +13,8 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ username }) => {
 
   return (
-      <View className="flex-col justify-between py-6 px-2">
-        <SimpleLogoSvg width={100} height={50} />
-
+      <View className="flex-col justify-between py-5 px-2">
+        <SimpleLogoSvg width={100} height={40} />
         <Text className="text-darkGreen text-4xl font-bold mt-3">
           Hello, {username}!
         </Text>


### PR DESCRIPTION
## **Summary**
Changed the routing for the "Scan Item" button in the Scan Widget to the camera page (same as the scan icon in the tab bar). Also, changed the border style of the home page widgets to match the borders in profile page's achievements. Did the same thing for the FAQ page.

Note: I just tested this on the simulator so I couldn't open the camera, but considering that the scan button in the tab bar is working, it should work on the scan item button as well.

## **Additional Information**
![simulator_screenshot_460DB55E-2AD2-47F6-AD09-2396BC4F54BD](https://github.com/user-attachments/assets/d8b92a65-1226-4589-b8d0-fe3637a12596)

![simulator_screenshot_48E48B9C-9E02-49F9-B4CD-19E0253D093A](https://github.com/user-attachments/assets/ef742cd4-2049-4b6d-8251-e872381e5a0e)
-3bc1-4300-8d22-0a3e17d91f8a)

Closes #127 